### PR TITLE
Publish to npm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - next
+      - next-major
       - beta
       - alpha
       - '*.*.x'   # Matches branches like '1.2.x', '2.3.x'
@@ -13,6 +14,7 @@ on:
     branches:
       - main
       - next
+      - next-major
       - beta
       - alpha
       - '*.*.x'   # Matches PRs targeting '1.2.x', '2.3.x'
@@ -99,8 +101,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22.x'
-          registry-url: 'https://npm.pkg.github.com'
-          scope: '@mitre-attack'
+          # registry-url: 'https://npm.pkg.github.com'
+          # scope: '@mitre-attack'
 
       - name: Install dependencies
         run: npm clean-install
@@ -115,7 +117,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # NPM_TOKEN: ${{ secrets.NPM_TOKEN }} DO NOT USE
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           HUSKY: 0  # Temporarily disables all Git hooks
         run: npx semantic-release
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 @mitre-attack:registry=https://npm.pkg.github.com
+@mitre-attack:registry=https://registry.npmjs.org/

--- a/README.md
+++ b/README.md
@@ -25,41 +25,15 @@ This site is dynamically generated from the contents of the `@latest` distributi
 
 ## Installation
 
-### Pre-requisites
+The ADM is available on both the npm registry and the GitHub package registry.
 
-To use the ATT&CK Data Model in your TypeScript project, you must first do two setup steps.
-
-1. Create a GitHub Personal Access Token with the `read:packages` scope. Full details can be found in this [GitHub documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-to-github-packages). The critical detail from that page is the following:
-
-> To authenticate by adding your personal access token (classic) to your ~/.npmrc file, edit the ~/.npmrc file for your project to include the following line, replacing TOKEN with your personal access token. Create a new ~/.npmrc file if one doesn't exist.
->
-> ```//npm.pkg.github.com/:_authToken=TOKEN```
-
-2. Second, set up a scoped registry for GitHub packages:
-
-```bash
-npm config set @mitre-attack:registry https://npm.pkg.github.com
-```
-
-If you encounter issues, you might need to explicitly add the npmjs.org registry for non-scoped packages:
-
-```bash
-npm config set registry https://registry.npmjs.org/
-```
-
-To verify your current configuration:
-
-```bash
-npm config list
-```
-
-### Install
-
-Now you can install the package:
+To install from the npm registry, simply run:
 
 ```bash
 npm install @mitre-attack/attack-data-model
 ```
+
+See [USAGE.md](./docs/USAGE.md#installing-from-github-package-registry) for instructions on how to install from the GitHub package registry.
 
 ## ATT&CK Specification
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -13,7 +13,41 @@ The ATT&CK Data Model (ADM) TypeScript API provides a structured and type-safe w
 
 ## Installation
 
-For installation instructions, please refer to the [Installation](../README.md#installation) section in the `README.md` file.
+For installation from the npm registry, please refer to the [Installation](../README.md#installation) section in the `README.md` file.
+
+### Installing from GitHub Package Registry
+
+Installing from the npm registry is the preferred solution. But if you must install the ATT&CK Data Model from GitHub's npm package registry, you can do so as follows:
+
+1. Create a GitHub Personal Access Token with the `read:packages` scope. Full details can be found in this [GitHub documentation](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry#authenticating-to-github-packages). The critical detail from that page is the following:
+
+> To authenticate by adding your personal access token (classic) to your ~/.npmrc file, edit the ~/.npmrc file for your project to include the following line, replacing TOKEN with your personal access token. Create a new ~/.npmrc file if one doesn't exist.
+>
+> ```//npm.pkg.github.com/:_authToken=TOKEN```
+
+2. Second, set up a scoped registry for GitHub packages:
+
+```bash
+npm config set @mitre-attack:registry https://npm.pkg.github.com
+```
+
+If you encounter issues, you might need to explicitly add the npmjs.org registry for non-scoped packages:
+
+```bash
+npm config set registry https://registry.npmjs.org/
+```
+
+To verify your current configuration:
+
+```bash
+npm config list
+```
+
+3. Now you can install the package:
+
+```bash
+npm install @mitre-attack/attack-data-model
+```
 
 ## Package Structure
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/mitre-attack/attack-data-model.git"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
+    "access": "public"
   },
   "author": {
     "name": "MITRE ATT&CK",


### PR DESCRIPTION
Closes #13

- Updated build files with the requisite information to publish to npm
- Updated installation instructions in README and USAGE
- Tested/verified the artifact can publish to the npm registry
- Tested/verified users can install the artifact from the npm registry by initializing a new project via `npm init` and running `npm i @mitre-attack/attack-data-model`
<img width="331" alt="image" src="https://github.com/user-attachments/assets/4afb28d3-aee1-4771-892d-0356e44dd283" />
