### PR TITLE
fix: fix for ESM imports

### DIFF
--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,1 +1,1 @@
-import './custom-error-map';
+import './custom-error-map.js';

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,7 +32,7 @@ import {
 import { AttackDataModel } from './classes/attack-data-model.js';
 
 // Initializes the custom ZodErrorMap
-import './errors';
+import './errors/index.js';
 
 const GITHUB_BASE_URL = 'https://raw.githubusercontent.com/mitre-attack/attack-stix-data/master';
 const readFile = promisify(fs.readFile);

--- a/src/schemas/sdo/asset.schema.ts
+++ b/src/schemas/sdo/asset.schema.ts
@@ -13,7 +13,7 @@ import {
 } from '../common/index.js';
 
 // Initializes the custom ZodErrorMap
-import '../../errors';
+import '../../errors/index.js';
 
 /////////////////////////////////////
 //

--- a/src/schemas/sdo/campaign.schema.ts
+++ b/src/schemas/sdo/campaign.schema.ts
@@ -14,7 +14,7 @@ import {
   objectMarkingRefsSchema,
 } from '../common/index.js';
 
-import '../../errors';
+import '../../errors/index.js';
 
 /////////////////////////////////////
 //

--- a/src/schemas/sdo/identity.schema.ts
+++ b/src/schemas/sdo/identity.schema.ts
@@ -9,7 +9,7 @@ import {
 } from '../common/open-vocabulary.js';
 
 // TODO migrate to loading this in a globally scoped module
-import '../../errors';
+import '../../errors/index.js';
 
 /////////////////////////////////////
 //

--- a/src/schemas/sdo/malware.schema.ts
+++ b/src/schemas/sdo/malware.schema.ts
@@ -15,7 +15,7 @@ import {
 
 // Initializes the custom ZodErrorMap
 // TODO migrate to loading this in a globally scoped module
-import '../../errors';
+import '../../errors/index.js';
 
 /////////////////////////////////////
 //

--- a/src/schemas/sdo/mitigation.schema.ts
+++ b/src/schemas/sdo/mitigation.schema.ts
@@ -12,7 +12,7 @@ import {
 
 // Initializes the custom ZodErrorMap
 // TODO migrate to loading this in a globally scoped module
-import '../../errors';
+import '../../errors/index.js';
 
 export const mitigationSchema = attackBaseObjectSchema
   .extend({

--- a/src/schemas/sdo/software.schema.ts
+++ b/src/schemas/sdo/software.schema.ts
@@ -14,7 +14,7 @@ import {
 
 // Initializes the custom ZodErrorMap
 // TODO migrate to loading this in a globally scoped module
-import '../../errors';
+import '../../errors/index.js';
 
 /////////////////////////////////////
 //

--- a/src/schemas/sdo/stix-bundle.schema.ts
+++ b/src/schemas/sdo/stix-bundle.schema.ts
@@ -21,7 +21,7 @@ import {
   markingDefinitionSchema,
 } from '../smo/marking-definition.schema.js';
 
-import '../../errors';
+import '../../errors/index.js';
 
 const STIX_BUNDLE_TYPE = stixTypeSchema.enum.bundle;
 

--- a/src/schemas/sdo/tactic.schema.ts
+++ b/src/schemas/sdo/tactic.schema.ts
@@ -12,7 +12,7 @@ import {
 import { stixTypeSchema } from '../common/stix-type.js';
 
 // Initializes the custom ZodErrorMap
-import '../../errors';
+import '../../errors/index.js';
 
 /////////////////////////////////////
 //

--- a/src/schemas/sdo/technique.schema.ts
+++ b/src/schemas/sdo/technique.schema.ts
@@ -14,7 +14,7 @@ import {
 } from '../common/index.js';
 
 // Initializes the custom ZodErrorMap
-import '../../errors';
+import '../../errors/index.js';
 
 // read only type reference
 const TECHNIQUE_TYPE: StixType = stixTypeSchema.enum['attack-pattern'];

--- a/src/schemas/sdo/tool.schema.ts
+++ b/src/schemas/sdo/tool.schema.ts
@@ -6,7 +6,7 @@ import { ToolTypesOpenVocabulary } from '../common/open-vocabulary.js';
 
 // Initializes the custom ZodErrorMap
 // TODO migrate to loading this in a globally scoped module
-import '../../errors';
+import '../../errors/index.js';
 
 /////////////////////////////////////
 //

--- a/src/schemas/sro/relationship.schema.ts
+++ b/src/schemas/sro/relationship.schema.ts
@@ -15,7 +15,7 @@ import {
 } from '../common/index.js';
 
 // Initializes the custom ZodErrorMap
-import '../../errors';
+import '../../errors/index.js';
 
 // read only type reference
 const RELATIONSHIP_TYPE: StixType = stixTypeSchema.enum.relationship;


### PR DESCRIPTION
This PR fixes use of attack-data-model with pure ESM applications.  Many imports lack `.js` extensions which are required in ESM, and when used the application immediately errors.