### PR TITLE
fix: fix npm build command (missing typescript definitions)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "email": "attack@mitre.org"
   },
   "scripts": {
-    "build": "npx tsup --format esm,cjs src",
+    "build": "npx tsup --dts --format esm,cjs src",
     "prepublishOnly": "rm -rf dist && npm run build",
     "test": "vitest --run",
     "test:interactive": "vitest",


### PR DESCRIPTION
This PR addresses https://github.com/mitre-attack/attack-data-model/issues/24, by adjusting the `build` package script to output typescript definitions.