### PR TITLE
fix: add duplicate detection for reference list properties

### DIFF
--- a/src/schemas/common/property-schemas/stix-attribution.ts
+++ b/src/schemas/common/property-schemas/stix-attribution.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/v4';
+import { uniqueArray } from './generics.js';
 import { createStixIdValidator, stixIdentifierSchema } from './stix-id.js';
 
 /**
@@ -15,14 +16,12 @@ import { createStixIdValidator, stixIdentifierSchema } from './stix-id.js';
  * objectMarkingRefsSchema.parse(['identity--12345']); // Invalid - must be marking-definition
  * ```
  */
-export const objectMarkingRefsSchema = z
-  .array(
-    stixIdentifierSchema.startsWith(
-      'marking-definition--',
-      'Identifier must start with "marking-definition--"',
-    ),
-  )
-  .meta({ description: 'The list of marking-definition objects to be applied to this object.' });
+export const objectMarkingRefsSchema = uniqueArray(
+  stixIdentifierSchema.startsWith(
+    'marking-definition--',
+    'Identifier must start with "marking-definition--"',
+  ),
+).meta({ description: 'The list of marking-definition objects to be applied to this object.' });
 
 // TODO add JSDoc
 export type ObjectMarkingRefs = z.infer<typeof objectMarkingRefsSchema>;

--- a/src/schemas/sdo/detection-strategy.schema.ts
+++ b/src/schemas/sdo/detection-strategy.schema.ts
@@ -4,6 +4,7 @@ import {
   createAttackExternalReferencesSchema,
   createStixIdValidator,
   createStixTypeValidator,
+  uniqueArray,
   xMitreContributorsSchema,
   xMitreDomainsSchema,
   xMitreModifiedByRefSchema,
@@ -27,9 +28,9 @@ export const detectionStrategySchema = attackBaseDomainObjectSchema
 
     x_mitre_contributors: xMitreContributorsSchema,
 
-    x_mitre_analytic_refs: z
-      .array(createStixIdValidator('x-mitre-analytic'))
-      .min(1, { error: 'At least one analytic ref is required' }),
+    x_mitre_analytic_refs: uniqueArray(createStixIdValidator('x-mitre-analytic')).min(1, {
+      error: 'At least one analytic ref is required',
+    }),
 
     x_mitre_domains: xMitreDomainsSchema,
   })

--- a/src/schemas/sdo/matrix.schema.ts
+++ b/src/schemas/sdo/matrix.schema.ts
@@ -4,6 +4,7 @@ import {
   createStixIdValidator,
   createStixTypeValidator,
   descriptionSchema,
+  uniqueArray,
   xMitreDomainsSchema,
   xMitreModifiedByRefSchema,
 } from '../common/property-schemas/index.js';
@@ -15,8 +16,7 @@ import {
 //
 //==============================================================================
 
-export const xMitreTacticRefsSchema = z
-  .array(createStixIdValidator('x-mitre-tactic'))
+export const xMitreTacticRefsSchema = uniqueArray(createStixIdValidator('x-mitre-tactic'))
   .min(1, { error: 'At least one tactic ref is required' })
   .meta({
     description:

--- a/test/objects/detection-strategy.test.ts
+++ b/test/objects/detection-strategy.test.ts
@@ -232,8 +232,8 @@ describe('detectionStrategySchema', () => {
         ...minimalDetectionStrategy,
         x_mitre_analytic_refs: [analyticId, analyticId, analyticId],
       };
-      // Schema doesn't prevent duplicates, so this should pass
-      expect(() => detectionStrategySchema.parse(detectionStrategyWithDuplicates)).not.toThrow();
+      // Schema prevents duplicates, so this should throw
+      expect(() => detectionStrategySchema.parse(detectionStrategyWithDuplicates)).toThrow();
     });
 
     it('should handle large number of analytics', () => {

--- a/test/utils/attack-data.test.ts
+++ b/test/utils/attack-data.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 describe('Global Tests', () => {
   describe('ATT&CK Testing Data', () => {
@@ -43,6 +43,8 @@ describe('Global Tests', () => {
         'x-mitre-matrix',
         'x-mitre-tactic',
         'x-mitre-asset',
+        'x-mitre-analytic',
+        'x-mitre-detection-strategy'
       ];
 
       const presentTypes = Object.keys(globalThis.attackData.objectsByType);
@@ -129,6 +131,8 @@ describe('Global Tests', () => {
         'x-mitre-data-source',
         'x-mitre-data-component',
         'x-mitre-asset',
+        'x-mitre-analytic',
+        'x-mitre-detection-strategy'
       ];
       const sdoCount = sdoTypes.reduce(
         (sum, type) => sum + (globalThis.attackData.objectsByType[type]?.length || 0),


### PR DESCRIPTION
## Summary

- Implements `uniqueArray()` utility function using Zod v4's `check()` method for array uniqueness validation
- Applies uniqueness constraints to all STIX reference list properties (`*_refs` suffix):
  - `object_marking_refs` 
  - `x_mitre_tactic_refs`
  - `x_mitre_analytic_refs`
- Updates test expectations to reflect duplicate prevention behavior
- Adds support for ATT&CK v18 SDO types (`x-mitre-analytic`, `x-mitre-detection-strategy`) in test data

The `uniqueArray()` function provides detailed error messages that specify which values are duplicated, improving the debugging experience. This prevents duplicate embedded relationships in STIX objects, ensuring data integrity across all reference properties.

## Test plan

- [x] Verify `uniqueArray()` function correctly identifies and reports duplicate values
- [x] Confirm all `*_refs` properties enforce uniqueness constraints
- [x] Validate updated test expectations for detection-strategy schema
- [x] Ensure ATT&CK v18 SDO types are properly recognized in test data validation
- [x] Run full test suite to verify no regressions