### PR TITLE
fix(detection-strategies): make x_mitre_contributors optional

### DIFF
--- a/src/schemas/sdo/detection-strategy.schema.ts
+++ b/src/schemas/sdo/detection-strategy.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod/v4';
+import { validateNoDuplicates } from '../../refinements/index.js';
 import { attackBaseDomainObjectSchema } from '../common/index.js';
 import {
   createAttackExternalReferencesSchema,
@@ -8,7 +9,6 @@ import {
   xMitreDomainsSchema,
   xMitreModifiedByRefSchema,
 } from '../common/property-schemas/index.js';
-import { validateNoDuplicates } from '../../refinements/index.js';
 
 //==============================================================================
 //
@@ -26,7 +26,7 @@ export const detectionStrategySchema = attackBaseDomainObjectSchema
 
     x_mitre_modified_by_ref: xMitreModifiedByRefSchema,
 
-    x_mitre_contributors: xMitreContributorsSchema,
+    x_mitre_contributors: xMitreContributorsSchema.optional(),
 
     x_mitre_analytic_refs: z
       .array(createStixIdValidator('x-mitre-analytic'))


### PR DESCRIPTION
## Hotfix: Make `x_mitre_contributors` optional on `x-mitre-detection-strategy`

### Summary
`x_mitre_contributors` was incorrectly marked as required on `x-mitre-detection-strategy` objects in ATT&CK spec v3.3.0. This PR makes the field optional, matching its intended behavior.

### Changes
- Relaxed `x_mitre_contributors` from required to optional on `x-mitre-detection-strategy`.
- `x_mitre_attack_spec_version` is intentionally **not** bumped — this is a corrective hotfix to v3.3.0, not a new spec revision.