### PR TITLE
fix(bundle): allow bundle parsing under Zod v4 pick-with-refinements …

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { logger } from '@/logger.js';
 
 import {
-  stixBundleSchema,
+  stixBundleBaseSchema,
   type AttackObject,
   type StixBundle,
 } from './schemas/sdo/stix-bundle.schema.js';
@@ -202,7 +202,7 @@ function parseStixBundle(rawData: StixBundle, parsingMode: ParsingMode): AttackO
   const validObjects: AttackObject[] = [];
 
   // Validate the bundle's top-level properties
-  const baseBundleValidationResults = stixBundleSchema
+  const baseBundleValidationResults = stixBundleBaseSchema
     .pick({
       id: true,
       type: true,

--- a/src/schemas/sdo/stix-bundle.schema.ts
+++ b/src/schemas/sdo/stix-bundle.schema.ts
@@ -160,7 +160,10 @@ export type AttackObjects = z.infer<typeof attackObjectsSchema>;
 //
 //==============================================================================
 
-export const stixBundleSchema = z
+// Base schema without refinements so it can be composed with `.pick()`, `.extend()`, etc.
+// Zod v4 forbids `.pick()` on schemas containing refinements (`.check()`), so the
+// refinements below are attached to `stixBundleSchema` rather than this base.
+export const stixBundleBaseSchema = z
   .object({
     id: createStixIdValidator('bundle'),
     type: createStixTypeValidator('bundle'),
@@ -190,20 +193,21 @@ export const stixBundleSchema = z
     description:
       'A Bundle is a collection of arbitrary STIX Objects grouped together in a single container. A Bundle does not have any semantic meaning and the objects contained within the Bundle are not considered related by virtue of being in the same Bundle. A STIX Bundle Object is not a STIX Object but makes use of the type and id Common Properties.',
   })
-  .strict()
-  .check((ctx) => {
-    // Validate that the first object is 'x-mitre-collection' and only one collection exists
-    validateXMitreCollection()(ctx);
+  .strict();
 
-    // Validate that all IDs referenced in 'x_mitre_contents' are present in 'objects' array
-    validateXMitreContentsReferences()(ctx);
+export const stixBundleSchema = stixBundleBaseSchema.check((ctx) => {
+  // Validate that the first object is 'x-mitre-collection' and only one collection exists
+  validateXMitreCollection()(ctx);
 
-    // Validate that no duplicate objects are present in 'objects' array
-    validateNoDuplicates(
-      ['objects'],
-      ['id'],
-      'Duplicate object with id "{id}" found. Each object in the bundle must have a unique id.',
-    )(ctx);
-  });
+  // Validate that all IDs referenced in 'x_mitre_contents' are present in 'objects' array
+  validateXMitreContentsReferences()(ctx);
+
+  // Validate that no duplicate objects are present in 'objects' array
+  validateNoDuplicates(
+    ['objects'],
+    ['id'],
+    'Duplicate object with id "{id}" found. Each object in the bundle must have a unique id.',
+  )(ctx);
+});
 
 export type StixBundle = z.infer<typeof stixBundleSchema>;


### PR DESCRIPTION
Fixes #67.

## Summary

`parseStixBundle` validates a bundle's top-level `id` and `type` by calling `stixBundleSchema.pick({ id: true, type: true })`. Zod v4 disallows `.pick()` on any schema that has refinements attached, and `stixBundleSchema` carries three (`validateXMitreCollection`, `validateXMitreContentsReferences`, `validateNoDuplicates`). As a result, every call into `registerDataSource` / `loadDataModel` threw:

> Error: .pick() cannot be used on object schemas containing refinements

## Fix

Split `stixBundleSchema` into two exports:

- `stixBundleBaseSchema` — the plain `z.object({...}).strict()` shape, no refinements. Safe to compose with `.pick()`, `.extend()`, etc.
- `stixBundleSchema` — `stixBundleBaseSchema.check(...)` with the existing collection/contents/duplicate refinements. Used for full bundle validation, unchanged.

`parseStixBundle` now picks `id` and `type` from `stixBundleBaseSchema`, which sidesteps the Zod v4 restriction without weakening any validation: the top-level check was always meant to be a shallow gate (note the existing `.loose()` so `objects` passes through to per-object validation), and full bundle validation via `stixBundleSchema` is still available to callers that want it.

## Test plan

- [x] `npx vitest run test/objects/stix-bundle.test.ts` — 23/23 pass
- [x] `npx vitest run test/documentation/README.test.ts` — 13/13 pass (exercises the `registerDataSource` → `loadDataModel` path from the bug report)
- [x] `npx tsc --noEmit` clean
- [X] Reproduce the original failing snippet from #67 against a local build and confirm it loads techniques/tactics without throwing